### PR TITLE
fix: move timestamp to same line as status indicators in prompt

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -1,11 +1,9 @@
 # This is the default format
 #format = '$all'
 format = """
-[╭─](#464646) $os$hostname$all$right_format\
+[╭─](#464646) $os$hostname$directory$git_branch$git_status$env_var
 [╰─](#464646)$character\
 """
-
-right_format = '$env_var'
 
 # Get editor completions based on the config schema
 "$schema" = 'https://starship.rs/config-schema.json'


### PR DESCRIPTION
Updated Starship config to display timestamp inline on the first line instead of wrapping to the second line. Replaced $all with explicit module list to have better control over layout and prevent unwanted line breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)